### PR TITLE
Fix test files not ignored in SonarCloud code duplication analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,8 @@ sonar.organization=software-engineering-2021-p9
 sonar.sources=client/,server/
 sonar.exclusions=**/node_modules/**
 sonar.coverage.exclusions=server/test/**/*,client/**/*
+sonar.cpd.exclusions=server/test/**/*
+sonar.test.exclusions=server/test/**/*
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This PR adds the test files to the exclusion list also for the duplication analysis on Sonarcloud.