### PR TITLE
Deleted check on lenght of the lists of ids

### DIFF
--- a/server/handlers/shared_validators.js
+++ b/server/handlers/shared_validators.js
@@ -89,7 +89,6 @@ exports.idsValidator = query("ids")
   .bail()
   .isString()
   .bail()
-  .isLength({ max: 100 })
   .trim()
   .custom((value) => {
     const splittedIDs = value.split(",");


### PR DESCRIPTION
Since the client can put how many different items s/he wants in the cart, I deleted the check on the length of the list of ids. Now it only checks if every id is a valid mongoId object