### PR TITLE
FE - Popup not covered orders

### DIFF
--- a/client/src/Routes.js
+++ b/client/src/Routes.js
@@ -15,6 +15,7 @@ import TestPanelPage from "./pages/TestPanelPage";
 
 const productListRouteName = "product-list-page";
 const shoppingCartRouteName = "shopping-cart-page";
+const ClientOrdersRouteName = "client-orders-page";
 const employeeClientManagementRouteName = "employee-client-management-page";
 const employeeClientDetailsRouteName = "employee-client-details-page";
 const employeeClientSignupRouteName = "employee-client-signup-page";
@@ -90,6 +91,12 @@ const routes = {
     exact: false,
     linkTitle: "Signup Client",
   },
+  [ClientOrdersRouteName]: {
+    path: "/ClientOrders",
+    component: ClientDetailsPage,
+    exact: false,
+    linkTitle: "My Orders",
+  },
   [farmerProductManagementRouteName]: {
     path: "/farmer/products",
     component: () => (
@@ -143,7 +150,10 @@ const routes = {
 function getAvailableNavbarLinks(loggedUser) {
   switch (loggedUser?.role) {
     case UserRoles.CLIENT:
-      return [userLogoutRouteName];
+      return [
+        userLogoutRouteName,
+        ClientOrdersRouteName
+      ];
     case UserRoles.EMPLOYEE:
       return [
         employeeClientManagementRouteName,

--- a/client/src/Routes.js
+++ b/client/src/Routes.js
@@ -2,7 +2,7 @@ import { ShoppingCartPage } from "./pages/ShoppingCartPage";
 import { ClientDetailsPage } from "./pages/ClientDetailsPage";
 import { ClientManagementPage } from "./pages/ClientManagementPage/ClientManagementPage";
 import { ClientSignupPage } from "./pages/ClientSignupPage";
-import { ProductListPage } from "./pages/ProductListPage";
+import { ProductListPage } from "./pages/ProductListPage/ProductListPage";
 import { ProductManagementPage } from "./pages/ProductManagementPage/ProductManagementPage";
 import { UserLoginPage } from "./pages/UserLoginPage";
 import { UserLogoutRedirect } from "./pages/UserLogoutRedirect";
@@ -15,7 +15,6 @@ import TestPanelPage from "./pages/TestPanelPage";
 
 const productListRouteName = "product-list-page";
 const shoppingCartRouteName = "shopping-cart-page";
-const ClientOrdersRouteName = "client-orders-page";
 const employeeClientManagementRouteName = "employee-client-management-page";
 const employeeClientDetailsRouteName = "employee-client-details-page";
 const employeeClientSignupRouteName = "employee-client-signup-page";
@@ -91,12 +90,6 @@ const routes = {
     exact: false,
     linkTitle: "Signup Client",
   },
-  [ClientOrdersRouteName]: {
-    path: "/ClientOrders",
-    component: ClientDetailsPage,
-    exact: false,
-    linkTitle: "My Orders",
-  },
   [farmerProductManagementRouteName]: {
     path: "/farmer/products",
     component: () => (
@@ -150,10 +143,7 @@ const routes = {
 function getAvailableNavbarLinks(loggedUser) {
   switch (loggedUser?.role) {
     case UserRoles.CLIENT:
-      return [
-        userLogoutRouteName,
-        ClientOrdersRouteName
-      ];
+      return [userLogoutRouteName];
     case UserRoles.EMPLOYEE:
       return [
         employeeClientManagementRouteName,

--- a/client/src/pages/ProductListPage.js
+++ b/client/src/pages/ProductListPage.js
@@ -42,7 +42,7 @@ function ProductListPage(props) {
 
   if(clientHasNotCoveredOrders === false && currentUser !== null && currentUser.role === "client"){
     getOrders(currentUser.id).then(orders=>{
-      if(orders.filter(order=>order.status === Order.OrderStatus.WAITING).length > 0)
+      if(orders.filter(order=>order.status === Order.OrderStatus.NOT_COVERED).length > 0)
         setClientHasNotCoveredOrders(true);
     }).catch(err=>{
       throw(err);
@@ -136,19 +136,25 @@ function ProductListPage(props) {
           })}
       </Row>
 
-      <Modal show={currentUser !== null && currentUser.role === "client" && clientHasNotCoveredOrders && firstTimeNotify}>
+      <Modal centered show={currentUser !== null && currentUser.role === "client" && clientHasNotCoveredOrders && firstTimeNotify}>
         <Modal.Header>
-          <Modal.Title>Not Covered Orders</Modal.Title>
+          <div style={{"margin":"auto"}}>
+            <Modal.Title >Not Covered Orders</Modal.Title>
+          </div>
         </Modal.Header>
 
         <Modal.Body>
           <p>At the moment there are "not covered orders" waiting for a wallet top up.</p>
-          <p>Not covered order will be deleted at the defined deadline.</p>
+          <p>Not covered orders will be deleted at the defined deadline.</p>
         </Modal.Body>
 
         <Modal.Footer>
-          <Button variant="secondary" onClick={()=>{setFirstTimeNotify(false)}}>Close</Button>
-          <Button variant="primary" onClick={()=>{history.push("/...")}}>Check Orders</Button>
+          <div style={{"margin":"auto"}}>
+            <Button variant="primary" onClick={()=>{setFirstTimeNotify(false)}} style={{"width":"10em"}} >Close</Button>
+          </div>
+            <div style={{"margin":"auto"}}>
+            <Button variant="primary" onClick={()=>{history.push("/ClientOrders")}} style={{"width":"10em"}}>Check Orders</Button>
+          </div>
         </Modal.Footer>
       </Modal>
     </>

--- a/client/src/pages/ProductListPage.js
+++ b/client/src/pages/ProductListPage.js
@@ -139,7 +139,7 @@ function ProductListPage(props) {
       <Modal centered show={currentUser !== null && currentUser.role === "client" && clientHasNotCoveredOrders && firstTimeNotify}>
         <Modal.Header>
           <div style={{"margin":"auto"}}>
-            <Modal.Title >Not Covered Orders</Modal.Title>
+            <Modal.Title >Insufficient Wallet Balance</Modal.Title>
           </div>
         </Modal.Header>
 
@@ -150,10 +150,10 @@ function ProductListPage(props) {
 
         <Modal.Footer>
           <div style={{"margin":"auto"}}>
-            <Button variant="primary" onClick={()=>{setFirstTimeNotify(false)}} style={{"width":"10em"}} >Close</Button>
+            <Button variant="primary" onClick={()=>{setFirstTimeNotify(false)}} style={{"width":"8em"}} >Close</Button>
           </div>
             <div style={{"margin":"auto"}}>
-            <Button variant="primary" onClick={()=>{history.push("/ClientOrders")}} style={{"width":"10em"}}>Check Orders</Button>
+            <Button variant="primary" onClick={()=>{history.push("/ClientOrders")}} style={{"width":"8em"}}>Check Orders</Button>
           </div>
         </Modal.Footer>
       </Modal>

--- a/client/src/pages/ProductListPage/ProductListPage.css
+++ b/client/src/pages/ProductListPage/ProductListPage.css
@@ -1,0 +1,10 @@
+.product-list-page-popup-buttons {
+  width: 8em;
+  margin: 3px;
+}
+.margin-auto {
+  margin: auto;
+}
+.center-text {
+  text-align: center;
+}

--- a/client/src/pages/ProductListPage/ProductListPage.js
+++ b/client/src/pages/ProductListPage/ProductListPage.js
@@ -44,7 +44,7 @@ function ProductListPage(props) {
 
   if(clientHasNotCoveredOrders === false && currentUser !== null && currentUser.role === "client"){
     getOrders(currentUser.id).then(orders=>{
-      if(orders.filter(order=>order.status === Order.OrderStatus.WAITING).length > 0)
+      if(orders.filter(order=>order.status === Order.OrderStatus.NOT_COVERED).length > 0)
         setClientHasNotCoveredOrders(true);
     }).catch(err=>{
       throw(err);

--- a/client/src/pages/ProductListPage/ProductListPage.js
+++ b/client/src/pages/ProductListPage/ProductListPage.js
@@ -146,8 +146,8 @@ function ProductListPage(props) {
         </Modal.Header>
 
         <Modal.Body>
-          <p className="center-text">At the moment there are "not covered orders" waiting for a wallet top up.</p>
-          <p className="center-text">Not covered will be deleted at the defined deadline.</p>
+          <p className="center-text">At the moment there are orders with status "not covered", waiting for a wallet top up.</p>
+          <p className="center-text">Not covered orders will be deleted at the defined deadline.</p>
         </Modal.Body>
 
         <Modal.Footer>

--- a/client/src/pages/ProductListPage/ProductListPage.js
+++ b/client/src/pages/ProductListPage/ProductListPage.js
@@ -1,19 +1,21 @@
 import { React, useEffect, useState, useContext } from "react";
 import { useLocation, useHistory } from "react-router";
 import { Row, Col, CardGroup, Modal, Button } from "react-bootstrap";
-import { getAvailableNavbarLinks } from "../Routes";
+import { getAvailableNavbarLinks } from "../../Routes";
 
-import { NavbarComponent } from "../ui-components/NavbarComponent/NavbarComponent";
-import { FilterRow } from "../ui-components/FilterRow/FilterRow";
-import ProductCard from "../ui-components/ProductCardComponent/ProductCard";
+import { NavbarComponent } from "../../ui-components/NavbarComponent/NavbarComponent";
+import { FilterRow } from "../../ui-components/FilterRow/FilterRow";
+import ProductCard from "../../ui-components/ProductCardComponent/ProductCard";
 
 import "bootstrap/dist/css/bootstrap.min.css";
+import "./ProductListPage.css";
+import { alertIcon } from "../../ui-components/icons"
 
-import { findProducts, getOrders } from "../services/ApiClient";
-import  Order  from "../services/models/Order"
+import { findProducts, getOrders } from "../../services/ApiClient";
+import  Order  from "../../services/models/Order"
 
-import { AuthContext } from "../contexts/AuthContextProvider";
-import UserRoles from "../services/models/UserRoles";
+import { AuthContext } from "../../contexts/AuthContextProvider";
+import UserRoles from "../../services/models/UserRoles";
 
 function ProductListPage(props) {
   const location = useLocation();
@@ -42,7 +44,7 @@ function ProductListPage(props) {
 
   if(clientHasNotCoveredOrders === false && currentUser !== null && currentUser.role === "client"){
     getOrders(currentUser.id).then(orders=>{
-      if(orders.filter(order=>order.status === Order.OrderStatus.NOT_COVERED).length > 0)
+      if(orders.filter(order=>order.status === Order.OrderStatus.WAITING).length > 0)
         setClientHasNotCoveredOrders(true);
     }).catch(err=>{
       throw(err);
@@ -138,22 +140,22 @@ function ProductListPage(props) {
 
       <Modal centered show={currentUser !== null && currentUser.role === "client" && clientHasNotCoveredOrders && firstTimeNotify}>
         <Modal.Header>
-          <div style={{"margin":"auto"}}>
-            <Modal.Title >Insufficient Wallet Balance</Modal.Title>
+          <div className="margin-auto center-text">
+            <Modal.Title className="margin-auto" > {alertIcon} Insufficient Wallet Balance</Modal.Title>
           </div>
         </Modal.Header>
 
         <Modal.Body>
-          <p>At the moment there are "not covered orders" waiting for a wallet top up.</p>
-          <p>Not covered orders will be deleted at the defined deadline.</p>
+          <p className="center-text">At the moment there are "not covered orders" waiting for a wallet top up.</p>
+          <p className="center-text">Not covered orders will be deleted at the defined deadline.</p>
         </Modal.Body>
 
         <Modal.Footer>
-          <div style={{"margin":"auto"}}>
-            <Button variant="primary" onClick={()=>{setFirstTimeNotify(false)}} style={{"width":"8em"}} >Close</Button>
+          <div className="margin-auto">
+            <Button className="product-list-page-popup-buttons" variant="primary" onClick={()=>{setFirstTimeNotify(false)}} >Close</Button>
           </div>
-            <div style={{"margin":"auto"}}>
-            <Button variant="primary" onClick={()=>{history.push("/ClientOrders")}} style={{"width":"8em"}}>Check Orders</Button>
+            <div className="margin-auto">
+            <Button className="product-list-page-popup-buttons" variant="primary" onClick={()=>{history.push("/client")}}>Check Orders</Button>
           </div>
         </Modal.Footer>
       </Modal>

--- a/client/src/pages/ProductListPage/ProductListPage.js
+++ b/client/src/pages/ProductListPage/ProductListPage.js
@@ -147,7 +147,7 @@ function ProductListPage(props) {
 
         <Modal.Body>
           <p className="center-text">At the moment there are "not covered orders" waiting for a wallet top up.</p>
-          <p className="center-text">Not covered orders will be deleted at the defined deadline.</p>
+          <p className="center-text">Not covered will be deleted at the defined deadline.</p>
         </Modal.Body>
 
         <Modal.Footer>

--- a/client/src/services/models/Order.js
+++ b/client/src/services/models/Order.js
@@ -27,6 +27,7 @@ class Order {
     CONFIRMED: "confirmed",
     PREPARED: "prepared",
     DONE: "done",
+    PENDINGCANCELATION: "pending-cancelation",
   };
 }
 

--- a/client/src/ui-components/ClientOrdersComponent/ClientOrderTableRow.css
+++ b/client/src/ui-components/ClientOrdersComponent/ClientOrderTableRow.css
@@ -1,8 +1,20 @@
 .table-row-status-prepared {
-  color: #ff9e0a !important;
+  color: rgb(130, 156, 44);
+}
+.table-row-status-waiting {
+  color: #635f46;
+}
+.table-row-status-confirmed {
+  color: darkolivegreen;
 }
 .table-row-status-done {
-  color: green !important;
+  color: rgb(68, 146, 4);
+}
+.table-row-status-not-covered {
+  color: rgb(218, 104, 47);
+}
+.table-row-status-pending-cancelation {
+  color: rgb(211, 2, 2);
 }
 .change-status {
   color: rgba(99, 95, 70, 1);

--- a/client/src/ui-components/ClientOrdersComponent/ClientOrderTableRow.js
+++ b/client/src/ui-components/ClientOrdersComponent/ClientOrderTableRow.js
@@ -24,6 +24,8 @@ function ClientOrderTableRow(props) {
     setModalIsOpen(false);
   };
 
+  let statusComponent = createStatusComponent(status);
+
   return (
     <Row className="my-3 px-0">
       <PopUpForCompleteOrder
@@ -47,15 +49,7 @@ function ClientOrderTableRow(props) {
         <Col md="3" lg="3" xl="3" className="mx-0 px-0">
           <Row>
             <Col className="d-flex align-items-center">
-              {status === Order.OrderStatus.DONE ? (
-                <span className="table-row-status-done mx-0 px-0">
-                  {status}
-                </span>
-              ) : (
-                <span className="table-row-status-prepared mx-0 px-0">
-                  {status}
-                </span>
-              )}
+              {statusComponent}
             </Col>
             {status === Order.OrderStatus.PREPARED &&
               props.loggedUser.role === UserRoles.EMPLOYEE && (
@@ -111,15 +105,9 @@ function ClientOrderTableRow(props) {
             <Col className="d-flex align-items-center" sm="auto" xs="auto">
               {statusIcon}
             </Col>
-            {status === Order.OrderStatus.DONE ? (
-              <Col className="table-row-status-done d-flex align-items-center">
-                {status}
-              </Col>
-            ) : (
-              <Col className="table-row-status-prepared d-flex align-items-center">
-                {status}
-              </Col>
-            )}
+            <Col className="d-flex align-items-center">
+              {statusComponent}
+            </Col>
             {status === Order.OrderStatus.PREPARED &&
               props.loggedUser.role === UserRoles.EMPLOYEE && (
                 <Col className="d-flex justify-content-end">
@@ -136,6 +124,54 @@ function ClientOrderTableRow(props) {
       </Row>
     </Row>
   );
+}
+
+function createStatusComponent(status){
+  let statusComponent;
+  switch(status){
+    case Order.OrderStatus.NOT_COVERED:
+      statusComponent =     
+        <span className="table-row-status-not-covered mx-0 px-0">
+          {status}
+        </span>
+      break;
+
+    case Order.OrderStatus.WAITING:
+      statusComponent =     
+        <span className="table-row-status-waiting mx-0 px-0">
+          {status}
+        </span>
+      break;
+
+    case Order.OrderStatus.PREPARED:
+      statusComponent =     
+        <span className="table-row-status-prepared mx-0 px-0">
+          {status}
+        </span>
+      break;
+
+    case Order.OrderStatus.DONE:
+      statusComponent =     
+        <span className="table-row-status-done mx-0 px-0">
+          {status}
+        </span>
+      break;
+
+    case Order.OrderStatus.PENDINGCANCELATION:
+      statusComponent =     
+        <span className="table-row-status-pending-cancelation mx-0 px-0">
+          {status}
+        </span>
+      break;
+
+    case Order.OrderStatus.CONFIRMED:
+      statusComponent =     
+        <span className="table-row-status-pending-confirmed mx-0 px-0">
+          {status}
+        </span>
+      break;
+  }
+  return statusComponent;
 }
 
 export { ClientOrderTableRow };

--- a/client/src/ui-components/ClientOrdersComponent/ClientOrderTableRow.js
+++ b/client/src/ui-components/ClientOrdersComponent/ClientOrderTableRow.js
@@ -170,6 +170,9 @@ function createStatusComponent(status){
           {status}
         </span>
       break;
+    default:
+      statusComponent = null;
+      break;
   }
   return statusComponent;
 }

--- a/client/src/ui-components/icons.js
+++ b/client/src/ui-components/icons.js
@@ -322,6 +322,21 @@ const phoneIcon = (
   </svg>
 );
 
+const alertIcon = (
+<svg 
+width="24px" 
+height="24px"
+fill="#db9471"
+viewBox="0 0 24 24" 
+xmlns="http://www.w3.org/2000/svg">
+  <g data-name="Layer 2"><g data-name="alert-triangle">
+    <rect width="24" height="24" transform="rotate(90 12 12)" opacity="0"/>
+    <path d="M22.56 16.3L14.89 3.58a3.43 3.43 0 0 0-5.78 0L1.44 16.3a3 3 0 0 0-.05 3A3.37 3.37 0 0 0 4.33 21h15.34a3.37 3.37 0 0 0 2.94-1.66 3 3 0 0 0-.05-3.04zm-1.7 2.05a1.31 1.31 0 0 1-1.19.65H4.33a1.31 1.31 0 0 1-1.19-.65 1 1 0 0 1 0-1l7.68-12.73a1.48 1.48 0 0 1 2.36 0l7.67 12.72a1 1 0 0 1 .01 1.01z"/><circle cx="12" cy="16" r="1"/>
+    <path d="M12 8a1 1 0 0 0-1 1v4a1 1 0 0 0 2 0V9a1 1 0 0 0-1-1z"/></g>
+  </g>
+</svg>
+)
+
 export {
   iconPackaging,
   iconCartPlus,
@@ -345,4 +360,5 @@ export {
   personIcon,
   emailIcon,
   phoneIcon,
+  alertIcon,
 };


### PR DESCRIPTION
Task:
https://polito-se2-21-09.myjetbrains.com/youtrack/issue/S202109SPG-132

Story:

Insufficient Balance Reminder:
As a registered client
I want to receive a reminder that my wallet balance is insufficient
So that I can top it up

- Added a popup that notify the presence of not covered orders for the client, in the "/" path (i.e. product list page).
- Added for client the possibility to open the page with own orders, from popup or navbar.
- Added colors for each order status (to highlight the not covered and pending cancellation ones).

![Senza titolo](https://user-images.githubusercontent.com/56077426/147863800-3c9cf848-5153-4577-94f3-b99a056e46b8.png)
![Senza titolo](https://user-images.githubusercontent.com/56077426/147865053-301897d7-7fbe-4759-9789-3d4bdf2208df.png)


 