### PR TITLE
Fix sorted orders

### DIFF
--- a/client/src/pages/ClientDetailsPage.js
+++ b/client/src/pages/ClientDetailsPage.js
@@ -66,9 +66,9 @@ function ClientDetailsPage(props) {
           //fetch orders:
           getOrders(result.id).then((newO) => {
             const sortedOrders = newO.sort(
-              (newer, older) => newer.createdAt < older.createdAt
+              (newer, older) =>
+                new Date(newer.createdAt) < new Date(older.createdAt)
             );
-
             setOrders(sortedOrders);
           });
         })

--- a/client/src/pages/ClientDetailsPage.js
+++ b/client/src/pages/ClientDetailsPage.js
@@ -65,11 +65,7 @@ function ClientDetailsPage(props) {
 
           //fetch orders:
           getOrders(result.id).then((newO) => {
-            const sortedOrders = newO.sort(
-              (newer, older) =>
-                new Date(newer.createdAt) < new Date(older.createdAt)
-            );
-            setOrders(sortedOrders);
+            setOrders(newO);
           });
         })
         .catch((err) =>

--- a/client/src/pages/ClientDetailsPage.js
+++ b/client/src/pages/ClientDetailsPage.js
@@ -65,9 +65,11 @@ function ClientDetailsPage(props) {
 
           //fetch orders:
           getOrders(result.id).then((newO) => {
-            setOrders(
-              newO.sort((newer, older) => newer.createdAt < older.createdAt)
+            const sortedOrders = newO.sort(
+              (newer, older) => newer.createdAt < older.createdAt
             );
+
+            setOrders(sortedOrders);
           });
         })
         .catch((err) =>

--- a/server/dao/order.js
+++ b/server/dao/order.js
@@ -17,6 +17,7 @@ exports.getOrdersByClientID = async (db, clientID) => {
   return db
     .collection(orderCollectionName)
     .find({ clientID: ObjectID(clientID) })
+    .sort({ createdAt: -1 })
     .toArray();
 };
 // ------------

--- a/server/test/test-data.js
+++ b/server/test/test-data.js
@@ -61,7 +61,7 @@ exports.ordersCollection = {
       ],
       status: "done",
       totalPrice: "12",
-      createdAt: "2021-12-16T13:00:07.616Z",
+      createdAt: "2021-12-17T13:00:07.616Z",
       shipmentInfo: {
         type: "pickup",
         pickUpSlot: "42200",
@@ -109,7 +109,7 @@ exports.ordersCollection2 = {
       ],
       status: "done",
       totalPrice: "12",
-      createdAt: "2021-12-16T13:00:07.616Z",
+      createdAt: "2021-12-17T13:00:07.616Z",
     },
     {
       _id: ObjectID("6187c957b288576ca26f8990"),

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -1308,6 +1308,22 @@ describe("Orders API tests:", () => {
 
           expect(res.body).to.be.eql([
             {
+              id: "6187c957b288576ca26f8999",
+              clientID: "6187c957b288576ca26f8257",
+              products: [
+                { productID: "6187c957b288576ca26f8258", quantity: 10 },
+                { productID: "6187c957b288576ca26f8259", quantity: 2 },
+              ],
+              status: "done",
+              totalPrice: "12",
+              createdAt: "2021-12-17T13:00:07.616Z",
+              shipmentInfo: {
+                type: "pickup",
+                pickUpSlot: "42200",
+                address: "Via of the market ",
+              },
+            },
+            {
               id: "6187c957b288576ca26f8251",
               clientID: "6187c957b288576ca26f8257",
               products: [
@@ -1322,22 +1338,6 @@ describe("Orders API tests:", () => {
                 type: "pickup",
                 pickUpSlot: "32200",
                 address: "Via Prapappo Ravanello 54",
-              },
-            },
-            {
-              id: "6187c957b288576ca26f8999",
-              clientID: "6187c957b288576ca26f8257",
-              products: [
-                { productID: "6187c957b288576ca26f8258", quantity: 10 },
-                { productID: "6187c957b288576ca26f8259", quantity: 2 },
-              ],
-              status: "done",
-              totalPrice: "12",
-              createdAt: "2021-12-16T13:00:07.616Z",
-              shipmentInfo: {
-                type: "pickup",
-                pickUpSlot: "42200",
-                address: "Via of the market ",
               },
             },
           ]);


### PR DESCRIPTION
The orders on Client Details Page should be now ordered from most recent to least